### PR TITLE
Add versions 10, 11 and 12

### DIFF
--- a/phpcq-plugin.json
+++ b/phpcq-plugin.json
@@ -9,7 +9,7 @@
     },
     "tool": {
       "phpunit": {
-        "constraints": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "constraints": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
         "sources": [
           {
             "type": "github",


### PR DESCRIPTION
This supersedes #2.

I scraped the experimental inline repository as it does not work - the tool versions are still not included in the upstream repository unless we put explicit download URLs in the local-repo.

Therefore we allow all the versions without further ado.